### PR TITLE
fix: removed unstyled flash on initial page load

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,9 +3,35 @@ import Document, {
   Head,
   Main,
   NextScript,
+  DocumentContext,
 } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
 
 class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+
+    try {
+      ctx.renderPage = () => originalRenderPage({
+        enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+      });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
+  }
+
   render() {
     return (
       <Html>


### PR DESCRIPTION
Added getInitialProps to initialize styled components and eliminate unstyled flash